### PR TITLE
Ensure impl section titles only appear when list is not empty

### DIFF
--- a/js/generate.js
+++ b/js/generate.js
@@ -251,18 +251,19 @@ function formatImplData(data, implType) {
     var sections = {"Shipped": "shipped", "Experimental": "experimental", "In development": "indevelopment", "Under consideration": "consideration"};
     for (var section in sections) {
         var uadata = data[sections[section]];
+        uadata = uadata.filter(function (ua) {
+          return browsers.indexOf(ua) !== -1;
+        });
         if (uadata.length) {
             var heading = document.createElement("p");
             heading.appendChild(document.createTextNode(section));
             heading.appendChild(document.createElement("br"));
             uadata.forEach(function(ua) {
-                if (browsers.indexOf(ua) !== -1) {
-                    var icon = document.createElement("img");
-                    icon.src = "../icons/" + ua + ".png";
-                    icon.height = 30;
-                    icon.alt = section + " in " + ua;
-                    heading.appendChild(icon);
-                }
+                var icon = document.createElement("img");
+                icon.src = "../icons/" + ua + ".png";
+                icon.height = 30;
+                icon.alt = section + " in " + ua;
+                heading.appendChild(icon);
             });
             div.appendChild(heading);
 


### PR DESCRIPTION
This commit ensures that browsers we're not interested in get filtered out from the implementation data right away.

The "Current Implementations" column details the implementation status in main browsers. Implementation data may contain information about other browsers though (e.g. Firefox for Android, Safari for iOS, Opera Mini). That information is filtered out and not rendered for the time being. However, the code still took that information into account to decide whether to render the section's title.

In other words, the code could generate an empty "Shipped" or "In development" implementation section.